### PR TITLE
Render stored conversation history in chat UI

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -215,20 +215,10 @@ def save_feedback(index: int):
 if "history" not in st.session_state:
     st.session_state.history = []
 
-# ─── Display chat history with feedback ───────────────────────────────────────
-# for i, msg in enumerate(st.session_state.history):
-#     with st.chat_message(msg["role"]):
-#         st.markdown(msg["content"])
-#     if msg["role"] == "assistant":
-#         prev = msg.get("feedback", None)
-#         st.session_state[f"feedback_{i}"] = prev
-#         st.feedback(
-#             "thumbs",
-#             key=f"feedback_{i}",
-#             disabled=prev is not None,
-#             on_change=save_feedback,
-#             args=[i],
-#         )
+# ─── Display chat history ─────────────────────────────────────────────────────
+for msg in st.session_state.history:
+    with st.chat_message(msg["role"]):
+        st.write(msg["content"])
 
 # ─── Chat input & response handling ────────────────────────────────────────────
 if user_input := st.chat_input("Say something"):


### PR DESCRIPTION
## Summary
- render the saved conversation history at the top of the chat so earlier turns remain visible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d520754ec8832aa2bf38f8218760ac